### PR TITLE
Add `kind` property to toasts

### DIFF
--- a/src/components/ToastBar.tsx
+++ b/src/components/ToastBar.tsx
@@ -33,26 +33,6 @@ const getTransformStyle = ({ position = "top" }: Toast) => {
   };
 };
 
-const KindIconWrapper = ({
-  children,
-  kind,
-}: {
-  children: React.ReactNode;
-  kind?: ToastKind;
-}) => {
-  return (
-    <svg
-      className={classNames(styles.icon, !!kind && styles[kind])}
-      xmlns="http://www.w3.org/2000/svg"
-      fill="none"
-      viewBox="0 0 24 24"
-      stroke="currentColor"
-    >
-      {children}
-    </svg>
-  );
-};
-
 const iconPaths: Record<ToastKind, string> = {
   success: "M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z",
   failure:
@@ -67,14 +47,20 @@ const KindIcon = ({ kind }: { kind?: ToastKind }) => {
   }
 
   return (
-    <KindIconWrapper kind={kind}>
+    <svg
+      className={classNames(styles.icon, !!kind && styles[kind])}
+      xmlns="http://www.w3.org/2000/svg"
+      fill="none"
+      viewBox="0 0 24 24"
+      stroke="currentColor"
+    >
       <path
         strokeLinecap="round"
         strokeLinejoin="round"
         strokeWidth={2}
         d={iconPaths[kind]}
       />
-    </KindIconWrapper>
+    </svg>
   );
 };
 

--- a/src/components/ToastBar.tsx
+++ b/src/components/ToastBar.tsx
@@ -1,7 +1,7 @@
 import classNames from "classnames";
 import React, { useEffect, useState } from "react";
 import { CSSTransition } from "react-transition-group";
-import { Toast } from "../types";
+import { Toast, ToastKind } from "../types";
 import styles from "./toast_bar.css";
 
 const getTransformStyle = ({ position = "top" }: Toast) => {
@@ -33,6 +33,51 @@ const getTransformStyle = ({ position = "top" }: Toast) => {
   };
 };
 
+const KindIconWrapper = ({
+  children,
+  kind,
+}: {
+  children: React.ReactNode;
+  kind?: ToastKind;
+}) => {
+  return (
+    <svg
+      className={classNames(styles.icon, !!kind && styles[kind])}
+      xmlns="http://www.w3.org/2000/svg"
+      fill="none"
+      viewBox="0 0 24 24"
+      stroke="currentColor"
+    >
+      {children}
+    </svg>
+  );
+};
+
+const iconPaths: Record<ToastKind, string> = {
+  success: "M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z",
+  failure:
+    "M10 14l2-2m0 0l2-2m-2 2l-2-2m2 2l2 2m7-2a9 9 0 11-18 0 9 9 0 0118 0z",
+  warning:
+    "M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z",
+};
+
+const KindIcon = ({ kind }: { kind?: ToastKind }) => {
+  if (!kind) {
+    return null;
+  }
+
+  return (
+    <KindIconWrapper kind={kind}>
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={2}
+        d={iconPaths[kind]}
+      />
+    </KindIconWrapper>
+  );
+};
+
 export const DefaultToastBar = ({
   children,
   toast,
@@ -47,7 +92,6 @@ export const DefaultToastBar = ({
   applyDefault: boolean;
 }) => {
   const [ref, setRef] = useState<HTMLDivElement | null>(null);
-
   const { position = "top" } = toast;
   const top = position.includes("top");
   const centered = position === "top" || position === "bottom";
@@ -103,12 +147,18 @@ export const DefaultToastBar = ({
       <div
         ref={setRef}
         onClick={toast.onClick}
-        className={classNames(styles.toastBar, {
-          [styles.default]: applyDefault,
-          [styles.clickable]: !!toast.onClick,
-        })}
+        className={classNames(
+          styles.toastBar,
+          toast.kind && styles[toast.kind],
+          {
+            [styles.default]: applyDefault,
+            [styles.clickable]: !!toast.onClick,
+            [styles.withIcon]: !!toast.kind,
+          }
+        )}
         style={toastStyles}
       >
+        {!!toast.kind && <KindIcon kind={toast.kind} />}
         {children}
       </div>
     </CSSTransition>

--- a/src/components/toast_bar.css
+++ b/src/components/toast_bar.css
@@ -16,6 +16,42 @@
   line-height: 1.25rem;
 }
 
+.toastBar.default.success {
+  border: 1px solid #34d399;
+}
+
+.toastBar.default.failure {
+  border: 1px solid #dc2626;
+}
+
+.toastBar.default.warning {
+  border: 1px solid #f59e0b;
+}
+
+.toastBar.default.withIcon {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.icon {
+  width: 20px;
+  height: 20px;
+  margin-right: 0.5rem;
+}
+
+.icon.success {
+  color: #34d399;
+}
+
+.icon.failure {
+  color: #dc2626;
+}
+
+.icon.warning {
+  color: #f59e0b;
+}
+
 .toastBar.clickable {
   cursor: pointer;
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -40,6 +40,7 @@ const useStore = create<{
       position: options?.position ?? "top",
       duration: options?.duration ?? Infinity,
       visible: options?.visible ?? true,
+      kind: options?.kind,
     };
     set((state) => ({ toasts: [...state.toasts, toast] }));
     return {

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,11 +6,13 @@ export type ToastPosition =
   | "top_left"
   | "top_right";
 
+export type ToastKind = "success" | "failure" | "warning";
 export interface ToastfulOptions {
   position?: ToastPosition;
   visible?: boolean;
   dismissOnClick?: boolean;
   duration?: number;
+  kind?: ToastKind;
 }
 
 export type Toast = {
@@ -20,12 +22,10 @@ export type Toast = {
   dismiss(): void;
   toggle(): void;
   onClick?(): void;
-  position?: ToastPosition;
-  duration?: number;
+  position: ToastPosition;
+  duration: number;
   visible: boolean;
+  kind?: ToastKind;
 };
 
-export type ToastInstance = {
-  dismiss(): void;
-  toggle(): void;
-};
+export type ToastInstance = Pick<Toast, "dismiss" | "toggle">;


### PR DESCRIPTION
Adds the `kind` property to `ToastfulOptions` to allow consumers to use a predefined type of toast out of the box. This change introduces three kinds:

* success (green with a check icon)
* failure (red with a cross icon)
* warning (orange/yellow with an alert/info icon)

You can specify the kind when launching a toast as below:

```tsx
toastful('Hello, world!', { kind: 'success' });
```